### PR TITLE
Main cycle update

### DIFF
--- a/src/common/helpers/index.ts
+++ b/src/common/helpers/index.ts
@@ -1,1 +1,2 @@
+export * from './promises';
 export * from './funcs';

--- a/src/common/helpers/promises.ts
+++ b/src/common/helpers/promises.ts
@@ -3,7 +3,7 @@ export async function allSettled<T>(promises: Promise<T>[]): Promise<T[]> {
   const results = await Promise.allSettled(promises);
   const failed = results.filter((r) => r.status === 'rejected');
   if (failed.length > 0) {
-    throw new Error(failed.map((r: any) => r.reason).join(''));
+    throw new Error(failed.map((r: any) => r.reason).join('\n'));
   }
 
   return results.map((r: any) => r.value) as T[];

--- a/src/common/helpers/promises.ts
+++ b/src/common/helpers/promises.ts
@@ -1,0 +1,10 @@
+// wait for all promises to resolve and throws if any error occurs
+export async function allSettled<T>(promises: Promise<T>[]): Promise<T[]> {
+  const results = await Promise.allSettled(promises);
+  const failed = results.filter((r) => r.status === 'rejected');
+  if (failed.length > 0) {
+    throw new Error(failed.map((r: any) => r.reason).join(''));
+  }
+
+  return results.map((r: any) => r.value) as T[];
+}

--- a/src/contracts/node-operators-registry-v1/node-operators-registry.utils.ts
+++ b/src/contracts/node-operators-registry-v1/node-operators-registry.utils.ts
@@ -7,5 +7,17 @@ export async function isPoLidoV1(
   opts: CallOverrides,
 ): Promise<boolean> {
   // TODO change to blockTag check after V2 deployment
-  return (await self.version(opts)).startsWith('1.');
+  try {
+    const v = await self.version(opts);
+    if (!v) {
+      // assume empty as early v1
+      return true;
+    }
+    // it's 1.0.0 and "1.0.1" for later versions 🤯
+    return v.replace(/("|')/, '').startsWith('1.');
+  } catch (e) {
+    const err = e as Error;
+    err.message = `Failed to check PoLido version: ${err.message}`;
+    throw err;
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,13 +22,21 @@ async function bootstrap() {
   const sentryDsn = configService.get('SENTRY_DSN') ?? undefined;
 
   // logger
-  app.useLogger(app.get(LOGGER_PROVIDER));
+  const logger = app.get(LOGGER_PROVIDER);
+  app.useLogger(logger);
 
   // sentry
   if (sentryDsn) {
     const release = `${APP_NAME}@${buildInfo.version}`;
     Sentry.init({ dsn: sentryDsn, release, environment });
   }
+
+  process.on('unhandledRejection', async (error: any) => {
+    logger.warn(
+      "Dangling promise rejection detected. It's not handled anywhere.",
+    );
+    logger.warn(error);
+  });
 
   // app
   await app.listen(appPort, '0.0.0.0');

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -108,8 +108,7 @@ export class MetricsService {
    * Return median value multiplier as defined in PIP-4
    */
   private getPerformanceMultiple(checkpointNum: number): number {
-    // TODO: identify starting checkpoint
-    if (checkpointNum < 100_500) {
+    if (checkpointNum < 42_943) {
       return 0.95;
     }
     return 0.98;

--- a/src/validators/validators.service.ts
+++ b/src/validators/validators.service.ts
@@ -176,7 +176,7 @@ export class ValidatorsService implements OnModuleInit {
   public async getActiveLidoValidatorsIds(
     opts: CallOverrides,
   ): Promise<number[]> {
-    const ids = isPoLidoV1(this.nodeOperatorsRegistryV1, opts)
+    const ids = (await isPoLidoV1(this.nodeOperatorsRegistryV1, opts))
       ? await this.getActiveLidoValidatorsIdsV1(opts)
       : await this.getActiveLidoValidatorsIdsV2(opts);
 


### PR DESCRIPTION
- Avoid separate metrics calculation. Use batched computation after main cycle completion instead.
- Add `allSettled` wrapper to make sure all async job completed to avoid race conditions.
- Fix missing `await` for `isPoLidoV1` method call.
- Remove redundant async around `scheduleJob`.
- Add actual checkpoint number for PB bump.