### PR TITLE
Use lidofinance fork for create-PR action

### DIFF
--- a/.github/workflows/generate-monikers.yml
+++ b/.github/workflows/generate-monikers.yml
@@ -27,7 +27,7 @@ jobs:
           > monikers.json
 
       - name: Create PR
-        uses: peter-evans/create-pull-request@v4
+        uses: lidofinance/create-pull-request@v4
         with:
           author: GitHub <noreply@github.com>
           commit-message: 'chore: update monikers.json'


### PR DESCRIPTION
To make it consistent across organization and avoid problems with potential v4 tag changes